### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/continuous.versioning.yml
+++ b/.github/workflows/continuous.versioning.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   version-main-branch-changes:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v2


### PR DESCRIPTION
Potential fix for [https://github.com/ahmad-luqman/github-devsecops-fundamentals/security/code-scanning/1](https://github.com/ahmad-luqman/github-devsecops-fundamentals/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or to the specific job. Since the job creates and pushes tags, it requires write access to repository contents. The minimal required permissions for this workflow are likely `contents: write`, as it needs to push tags to the repository. You should add the following block under the job definition (or at the workflow root if you want it to apply to all jobs):

```yaml
permissions:
  contents: write
```

This should be added as the first key under the job `version-main-branch-changes:` (line 11), before `runs-on:`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
